### PR TITLE
READMEをmacOS/WSL2両対応の手順に更新する

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 シェル・エディタ・Claude Code などの個人用設定をまとめたリポジトリ。
 
+## 対応環境
+
+| 環境 | 状態 | 備考 |
+|------|------|------|
+| macOS | フル対応 | Homebrew・cask・Brewfile を含むすべてが利用可能 |
+| WSL2 (Ubuntu/Debian 系) | 部分対応 | mise／link.sh／一部の Brewfile はそのまま利用可能。cask・macOS 専用アプリは対象外 |
+
+`bash/.bashrc` は `OSTYPE` を判定して macOS は `.bash_bsd_aliases`、Linux (WSL2 含む) は `.bash_gnu_aliases` を読み込む。OS 固有の差分はその 2 ファイルに閉じる方針。
+
 ## ディレクトリ構成
 
 | パス | 内容 |
@@ -10,7 +19,7 @@
 | `zsh/` | zsh の設定（`.zshrc`） |
 | `vim/` | vim の設定（`.vimrc` ほか） |
 | `claude/` | Claude Code のグローバル設定（`CLAUDE.md`、`rules/`、`skills/`、`commands/`、`settings.json`） |
-| `Brewfile` | Homebrew で管理するパッケージ |
+| `Brewfile` | Homebrew で管理するパッケージ（macOS 前提） |
 | `mise.toml` / `mise.mk` | mise で管理するツール定義と bootstrap／install 用の Makefile |
 | `.fzf.bash` / `.fzf.zsh` | fzf の設定 |
 | `.ideavimrc` | IdeaVim の設定 |
@@ -18,7 +27,7 @@
 
 ## セットアップ
 
-### 1. mise のインストールとツール導入
+### 1. mise のインストールとツール導入（macOS / WSL2 共通）
 
 各種ツール（言語ランタイム、CLI ユーティリティなど）は [mise](https://mise.jdx.dev/) で管理する。`mise.mk` に bootstrap / install のターゲットを定義しているので、make 経由で実行する。
 
@@ -37,7 +46,7 @@ make -f mise.mk install     # mise.toml に定義されたツールを一括イ�
 
 symlink される対象は `link.sh` を参照すること（`.zshrc`、`.bashrc`、`.bash_profile`、`.bash_aliases`、`.vimrc`、`.ideavimrc`、`.fzf.zsh`、`.fzf.bash` など）。
 
-### 2. Vim プラグイン
+### 2. Vim プラグイン（macOS / WSL2 共通）
 
 vim を起動して以下を実行すると、`dein.toml` のプラグインが導入される。
 
@@ -45,17 +54,40 @@ vim を起動して以下を実行すると、`dein.toml` のプラグインが�
 :source ~/.vimrc
 ```
 
-### 3. Homebrew パッケージ
+### 3. パッケージインストール
 
-`Brewfile` のパッケージを一括インストールする場合は以下を実行する。
+#### 3a. macOS
+
+`Brewfile` のパッケージを一括インストールする。
 
 ```bash
 brew bundle --file=Brewfile
 ```
 
-### 4. Claude Code 設定
+`Brewfile` には formula／cask／VSCode 拡張／Go tools がまとまっており、macOS ではこれだけで網羅できる。
 
-`claude/` 配下の設定は Claude Code 側のグローバル設定ディレクトリ（`~/.claude/`）にリンクして利用する。詳細は `claude/CLAUDE.md` を参照。
+#### 3b. WSL2
+
+WSL2 では Homebrew (Linuxbrew) も導入は可能だが、`Brewfile` に含まれる `cask` (Raycast、Warp、aws-vault-binary など) は macOS 専用なので利用できない。また Linuxbrew は GUI アプリ系の依存解決が macOS と異なり、衝突や容量肥大の原因になりやすい。そのため WSL2 では以下のように使い分けることを推奨する。
+
+- 言語ランタイム・CLI ユーティリティの大半は **mise (`mise.toml`) で導入済み**なので追加作業は不要
+- `Brewfile` に列挙されている formula のうち WSL2 でも欲しいもの（例: `coreutils`、`gnupg`、`pre-commit`、`git-extras`、`vim`、`mysql` など）は **`apt` で代替**する
+- `cask` は対象外（macOS GUI アプリは対象 OS で別途インストールする。Raycast / Warp などは Windows 側、または Windows 用の代替ツールを使う）
+- VSCode 拡張は **VSCode の Sync Settings 機能** で WSL 側にも展開する（または `code --install-extension <id>` で個別導入）
+- Go tools は WSL2 上の Go (mise 管理) を使って **`go install` で個別導入**する
+
+apt での代替例。
+
+```bash
+sudo apt update
+sudo apt install -y coreutils gnupg pre-commit git-extras vim mysql-client
+```
+
+Linuxbrew をどうしても使いたい formula が出てきた場合は、対象を絞って手動インストールするのがよい (`brew install <formula>`)。`brew bundle --file=Brewfile` をそのまま実行すると cask が原因で失敗するため非推奨。
+
+### 4. Claude Code 設定（macOS / WSL2 共通）
+
+`claude/` 配下の設定は Claude Code 側のグローバル設定ディレクトリ（`~/.claude/`）にリンクして利用する。`link.sh` が symlink を張るため、`mise install` または `./link.sh` の実行で自動的に有効化される。詳細は `claude/CLAUDE.md` を参照。
 
 ## 運用ルール
 


### PR DESCRIPTION
## 概要

- fixed https://github.com/NAKKA-K/dotfiles/issues/10

READMEのセットアップ手順を macOS / WSL2 の両環境に対応した記述へ更新する。

## 背景

このdotfilesリポジトリはmacOS前提の手順で書かれていたが、実際にはWSL2上でも利用される。Brewfileに含まれる cask (Raycast、Warp、aws-vault-binary 等) や macOS 専用 formula は WSL2 では使えず、`brew bundle --file=Brewfile` をそのまま流すと失敗する。READMEを見ても WSL2 ユーザーが正しい手順に辿り着けない状態だった。

## 目的

- macOS / WSL2 のいずれでも、READMEだけでセットアップを完結できるようにする
- WSL2 では Brewfile がそのまま使えないことを明示し、apt 等の代替を案内する
- 共通手順 (mise / link.sh / vim / Claude Code) と OS 固有手順を明確に分離する

## 実装内容

- 対応環境テーブルを新設し、macOS = フル対応、WSL2 = 部分対応であることを明示
- `bash/.bashrc` の `OSTYPE` 判定方針 (`.bash_bsd_aliases` / `.bash_gnu_aliases`) を記載
- セットアップ手順を共通 (mise / vim / Claude Code) と OS 別 (Brew / apt) に分割
- パッケージインストールを 3a (macOS: `brew bundle`) / 3b (WSL2: apt + VSCode Sync + `go install`) に分け、WSL2 では cask が使えない旨と Linuxbrew をそのまま使うべきでない理由を補足

## ブランチ環境URL

該当なし。

## 検証内容

- [x] README をプレビューし、Markdown 構造（h2 から始まり、見出し記法を使用、コロン+箇条書きを避ける）がグローバル設定に沿っていることを確認
- [ ] 実際に WSL2 環境でREADME手順どおりにセットアップできるかをユーザーが検証する
- [ ] macOSでの既存手順が引き続き動作することをユーザーが検証する