### PR TITLE
fix: rewrite FZF_DEFAULT_OPTS as single-line space-separated

### DIFF
--- a/.fzf.bash
+++ b/.fzf.bash
@@ -3,17 +3,7 @@ eval "$(fzf --bash)"
 
 curl -s https://raw.githubusercontent.com/wfxr/forgit/master/forgit.plugin.zsh | bash
 
-export FZF_DEFAULT_OPTS="
---ansi
---height='80%'
---bind='alt-k:preview-up,alt-p:preview-up'
---bind='alt-j:preview-down,alt-n:preview-down'
---bind='ctrl-r:toggle-all'
---bind='ctrl-s:toggle-sort'
---bind='?:toggle-preview'
---bind='alt-w:toggle-preview-wrap'
---preview-window='right:60%'
-"
+export FZF_DEFAULT_OPTS="--ansi --height=80% --bind=alt-k:preview-up,alt-p:preview-up --bind=alt-j:preview-down,alt-n:preview-down --bind=ctrl-r:toggle-all --bind=ctrl-s:toggle-sort --bind=?:toggle-preview --bind=alt-w:toggle-preview-wrap --preview-window=right:60%"
 
 # Custom command
 # ------------

--- a/.fzf.zsh
+++ b/.fzf.zsh
@@ -1,17 +1,7 @@
 # Shell integration
 eval "$(fzf --zsh)"
 
-export FZF_DEFAULT_OPTS="
---ansi
---height='80%'
---bind='alt-k:preview-up,alt-p:preview-up'
---bind='alt-j:preview-down,alt-n:preview-down'
---bind='ctrl-r:toggle-all'
---bind='ctrl-s:toggle-sort'
---bind='?:toggle-preview'
---bind='alt-w:toggle-preview-wrap'
---preview-window='right:60%'
-"
+export FZF_DEFAULT_OPTS="--ansi --height=80% --bind=alt-k:preview-up,alt-p:preview-up --bind=alt-j:preview-down,alt-n:preview-down --bind=ctrl-r:toggle-all --bind=ctrl-s:toggle-sort --bind=?:toggle-preview --bind=alt-w:toggle-preview-wrap --preview-window=right:60%"
 
 # Custom command
 # ------------


### PR DESCRIPTION
## 概要

- fixed https://github.com/NAKKA-K/dotfiles/issues/12

cmux 環境で `gsw` / `glol` などの fzf エイリアスが `unknown option: --ansi--height=80%--bind=...` で失敗する問題を修正する。`FZF_DEFAULT_OPTS` を 1 行スペース区切りに書き換え、ターミナルやシェル起動経路に依存せず確実に fzf へ渡せる形式に統一する。

## 背景

`.fzf.zsh` / `.fzf.bash` の `FZF_DEFAULT_OPTS` は複数行文字列に各値をシングルクォートで囲んだ形で定義していた。Warp では問題なかったが cmux に移行後、fzf に渡される時点で改行とシングルクォートが除去され、全フラグが連結された単一トークンになりエラーが発生していた。

```
❯ gsw
unknown option: --ansi--height=80%--bind=alt-k:preview-up,alt-p:preview-up--bind=alt-j:preview-down,alt-n:preview-down--bind=ctrl-r:toggle-all--bind=ctrl-s:toggle-sort--bind=?:toggle-preview--bind=alt-w:toggle-preview-wrap--preview-window=right:60%
```

cmux / ghostty 経由のシェル起動経路、または fzf 側の `FZF_DEFAULT_OPTS` 解析のどちらが起因かまでは特定できていないが、複数行 + 内部シングルクォートという書式そのものが脆い。

## 目的

シェル / ターミナルエミュレータ / fzf のバージョンに依存せず、`FZF_DEFAULT_OPTS` を確実に fzf へ渡せるよう堅牢化する。

## 実装内容

- `.fzf.zsh` の `FZF_DEFAULT_OPTS` を 1 行スペース区切りに変更
- `.fzf.bash` の `FZF_DEFAULT_OPTS` を 1 行スペース区切りに変更
- 外側がダブルクォートのため意味を持たない内部シングルクォートを除去（`80%`、`right:60%` 等はそのまま fzf に渡って問題ない）

## ブランチ環境URL

なし（dotfiles リポジトリのためブランチ環境は提供されない）

## 検証内容

- [ ] cmux のシェルで `source ~/.fzf.zsh` 後、`gsw` を起動し fzf 画面が表示されること
- [ ] cmux のシェルで `glol` を起動し fzf 画面が表示されること
- [ ] Warp など他ターミナルでも従来通り `gsw` / `glol` が動作すること